### PR TITLE
Change directories before pip installation on M1 mac install

### DIFF
--- a/install_colabbatch_M1mac.sh
+++ b/install_colabbatch_M1mac.sh
@@ -40,6 +40,7 @@ conda install -y -c apple tensorflow-deps
 wget -qnc https://raw.githubusercontent.com/YoshitakaMo/localcolabfold/main/update_M1mac.sh --no-check-certificate
 chmod +x update_M1mac.sh
 # install ColabFold and Jaxlib
+cd localcolabfold
 colabfold-conda/bin/python3.10 -m pip install tensorflow-macos
 colabfold-conda/bin/python3.10 -m pip install git+https://github.com/deepmind/tree.git
 colabfold-conda/bin/python3.10 -m pip install git+https://github.com/google/ml_collections.git


### PR DESCRIPTION
I had the same issue as https://github.com/YoshitakaMo/localcolabfold/issues/180, and found that the binary was being called from the wrong location in the filesystem. Just added a directory change to be able to find the files