### PR TITLE
Add note on making installation folder case-sensitive on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more details, see [Flags](#flags) and `colabfold_batch --help`.
 
 ### For WSL2 (in Windows)
 
-**Caution: If your installation fails due to symbolic link (`symlink`) creation issues, this is due to the Windows file system being case-insensitive (while Linux file system is case-sensitive).** To resolve this, run the following command on Windows Powershell:
+**Caution: If your installation fails due to symbolic link (`symlink`) creation issues, this is due to the Windows file system being case-insensitive (while the Linux file system is case-sensitive).** To resolve this, run the following command on Windows Powershell:
 ```
 fsutil file SetCaseSensitiveInfo path\to\localcolabfold\installation enable
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,14 @@ It is recommended to add this export command to `~/.bashrc` and restart bash (`~
 
 For more details, see [Flags](#flags) and `colabfold_batch --help`.
 
-#### For WSL2 (in windows)
+### For WSL2 (in Windows)
+
+**Caution: If your installation fails due to symbolic link (`symlink`) creation issues, this is due to the Windows file system being case-insensitive (while Linux file system is case-sensitive).** To resolve this, run the following command on Windows Powershell:
+```
+fsutil file SetCaseSensitiveInfo path\to\localcolabfold\installation enable
+```
+
+Replace `path\to\colabfold\installation` with the path to the directory where you are installing LocalColabFold. Also, make sure that you are running the command on Windows Powershell (not WSL). For more details, see [Adjust Case Sensitivty (Microsoft)](https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity).
 
 Before running the prediction:
 


### PR DESCRIPTION
Hello! I encountered a `symlink` creation issue when attempting to install on Windows via WSL2. Turns out the Windows file system's case-insensitivity is messing up the installation of Mamba. 

Just added a small note in the README on making the LocalColabFold installation folder case-sensitive on Windows.