### PR TITLE
Add linux-aarch64 platform support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.12.12"
 
 [tool.pixi.workspace]
 channels = ["conda-forge", "bioconda"]
-platforms = ["linux-64", "osx-arm64"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 authors = [
     "Yoshitaka Moriwaki <moriwaki.yoshitaka@tmd.ac.jp, moriwaki@bi.a.u-tokyo.ac.jp>"
 ]
@@ -25,6 +25,23 @@ numpy = "<=2.1.3"
 colabfold = { git = "git+https://github.com/sokrypton/ColabFold", extras = ["alphafold-minus-jax"] }
 # colabfold = "==1.5.5"
 jax = { version = "==0.5.3", extras = ["cuda12"] }
+tensorflow = "==2.19.1"
+tqdm = "==4.66.1"
+silence_tensorflow = "==1.2.3"
+
+[tool.pixi.target.linux-aarch64.dependencies]
+git = "*"
+openmm = "==8.2.0"
+pdbfixer = "==1.10"
+kalign2 = "==2.04"
+hhsuite = "==3.3.0"
+mmseqs2 = "*"
+numpy = "<=2.1.3"
+
+[tool.pixi.target.linux-aarch64.pypi-dependencies]
+colabfold = { git = "git+https://github.com/sokrypton/ColabFold", extras = ["alphafold-minus-jax"] }
+# colabfold = "==1.5.5"
+jax = { version = "==0.6.2", extras = ["cuda12"] }
 tensorflow = "==2.19.1"
 tqdm = "==4.66.1"
 silence_tensorflow = "==1.2.3"


### PR DESCRIPTION
This PR makes localcolabfold pixi installable on ARM64 systems and was tested on a DGX Spark. This addresses issues #201 and #313.

The `run_colabfoldbatch_sample.sh` script runs on GPU, including `--use-gpu-relax`.